### PR TITLE
Fix explicit casts

### DIFF
--- a/dist/db/core.js
+++ b/dist/db/core.js
@@ -284,7 +284,7 @@ class SQLFragment {
                 }
                 else if (typeof expression.cast === 'string') {
                     result.values.push(expression.value);
-                    result.text += `CAST(${placeholder} AS "${expression.cast}")`;
+                    result.text += `CAST(${placeholder} AS ${expression.cast})`;
                 }
                 else {
                     result.values.push(expression.value);

--- a/src/db/core.ts
+++ b/src/db/core.ts
@@ -347,7 +347,7 @@ export class SQLFragment<RunResult = pg.QueryResult['rows'], Constraint = never>
 
       } else if (typeof expression.cast === 'string') {
         result.values.push(expression.value);
-        result.text += `CAST(${placeholder} AS "${expression.cast}")`;
+        result.text += `CAST(${placeholder} AS ${expression.cast})`;
 
       } else {
         result.values.push(expression.value);


### PR DESCRIPTION
This fixes https://github.com/jawj/zapatos/issues/180.  @dmitri-anchorzero this could be of use in the new json subquery stuff when using zapatos.param()